### PR TITLE
Use go.uber.org import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: go
+go_import_path: go.uber.org/thriftrw
 
 go:
   - 1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: go
-go_import_path: go.uber.org/thriftrw
+go_import_path: go.uber.org/atomic
 
 go:
   - 1.5
@@ -16,5 +16,6 @@ install:
 
 script:
   - make test_ci
+  - scripts/test-ubergo.sh
   - make lint
   - travis_retry goveralls -coverprofile=cover.out -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # atomic [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-Simple numeric wrappers to enforce atomic access.
+Simple wrappers for primitive types to enforce atomic access.
 
 ## Installation
-`go get -u github.com/uber-go/atomic`
+`go get -u go.uber.org/atomic`
 
 ## Usage
 The standard library's `sync/atomic` is powerful, but it's easy to forget which

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Simple wrappers for primitive types to enforce atomic access.
 
 ## Usage
 The standard library's `sync/atomic` is powerful, but it's easy to forget which
-variables must be accessed atomically. `uber-go/atomic` preserves all the
-functionality of the standard library, but wraps the primitive numeric types to
+variables must be accessed atomically. `go.uber.org/atomic` preserves all the
+functionality of the standard library, but wraps the primitive types to
 provide a safer, more convenient API.
 
 ```go
@@ -27,7 +27,7 @@ Stable.
 Released under the [MIT License](LICENSE.txt).
 
 [doc-img]: https://godoc.org/github.com/uber-go/atomic?status.svg
-[doc]: https://godoc.org/github.com/uber-go/atomic
+[doc]: https://godoc.org/go.uber.org/atomic
 [ci-img]: https://travis-ci.org/uber-go/atomic.svg?branch=master
 [ci]: https://travis-ci.org/uber-go/atomic
 [cov-img]: https://coveralls.io/repos/github/uber-go/atomic/badge.svg?branch=master

--- a/atomic.go
+++ b/atomic.go
@@ -20,7 +20,7 @@
 
 // Package atomic provides simple wrappers around numerics to enforce atomic
 // access.
-package atomic
+package atomic // import "go.uber.org/atomic"
 
 import (
 	"math"

--- a/atomic.go
+++ b/atomic.go
@@ -20,7 +20,7 @@
 
 // Package atomic provides simple wrappers around numerics to enforce atomic
 // access.
-package atomic // import "go.uber.org/atomic""
+package atomic // import "go.uber.org/atomic"
 
 import (
 	"math"

--- a/atomic.go
+++ b/atomic.go
@@ -20,7 +20,7 @@
 
 // Package atomic provides simple wrappers around numerics to enforce atomic
 // access.
-package atomic // import "go.uber.org/atomic"
+package atomic
 
 import (
 	"math"

--- a/atomic.go
+++ b/atomic.go
@@ -20,7 +20,7 @@
 
 // Package atomic provides simple wrappers around numerics to enforce atomic
 // access.
-package atomic // import "go.uber.org/atomic"
+package atomic // import "go.uber.org/atomic""
 
 import (
 	"math"

--- a/example_test.go
+++ b/example_test.go
@@ -23,7 +23,7 @@ package atomic_test
 import (
 	"fmt"
 
-	"github.com/uber-go/atomic"
+	"go.uber.org/atomic"
 )
 
 func Example() {

--- a/example_test.go
+++ b/example_test.go
@@ -18,12 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package atomic_test
+package atomic
 
 import (
 	"fmt"
 
-	"go.uber.org/atomic"
+	atomic "."
 )
 
 func Example() {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: f14d51408e3e0e4f73b34e4039484c78059cd7fc5f4996fdd73db20dc8d24f53
-updated: 2016-10-19T23:01:21.556384533-07:00
+updated: 2016-10-27T00:10:51.16960137-07:00
 imports: []
 testImports:
 - name: github.com/davecgh/go-spew
@@ -15,5 +15,3 @@ testImports:
   subpackages:
   - assert
   - require
-- name: github.com/uber-go/atomic
-  version: 0c9e689d64f004564b79d9a663634756df322902

--- a/glide.lock
+++ b/glide.lock
@@ -1,9 +1,19 @@
-hash: 5db1b05d931e409a41d0ab37d40a2983587ad1819c0b22738d28a40a96dbcca3
-updated: 2016-05-31T17:23:31.371153043-07:00
-imports:
+hash: f14d51408e3e0e4f73b34e4039484c78059cd7fc5f4996fdd73db20dc8d24f53
+updated: 2016-10-19T23:01:21.556384533-07:00
+imports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
-  version: 8d64eb7173c7753d6419fd4a9caf057398611364
+  version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
   - require
-devImports: []
+- name: github.com/uber-go/atomic
+  version: 0c9e689d64f004564b79d9a663634756df322902

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,5 @@
-package: github.com/uber-go/atomic
-import:
-# Test dependencies
+package: go.uber.org/atomic
+testImport:
 - package: github.com/stretchr/testify
   subpackages:
   - assert

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -3,7 +3,7 @@
 set -e
 
 COVER=cover
-ROOT_PKG=github.com/uber-go/atomic
+ROOT_PKG=go.uber.org/atomic
 
 if [[ -d "$COVER" ]]; then
 	rm -rf "$COVER"

--- a/scripts/test-ubergo.sh
+++ b/scripts/test-ubergo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# This script creates a fake GOPATH, symlinks in the current
+# directory as uber-go/atomic and verifies that tests still pass.
+
+WORK_DIR=`mktemp -d`
+
+echo "work dir $WORK_DIR"
+function cleanup {
+	# rm -rf "$WORK_DIR"
+	echo "WORK DIR"
+}
+trap cleanup EXIT
+
+
+export GOPATH="$WORK_DIR"
+
+PKG_PARENT="$WORK_DIR/src/github.com/uber-go"
+PKG_DIR="$PKG_PARENT/atomic"
+
+echo "pkg parent $PKG_PARENT"
+echo "pkg dir $PKG_DIR"
+echo ln -s `pwd` "PKG_DIR"
+mkdir -p "$PKG_PARENT"
+ln -s `pwd` "$PKG_DIR"
+cd "$PKG_DIR"
+
+make test

--- a/scripts/test-ubergo.sh
+++ b/scripts/test-ubergo.sh
@@ -6,23 +6,16 @@ IFS=$'\n\t'
 # directory as uber-go/atomic and verifies that tests still pass.
 
 WORK_DIR=`mktemp -d`
-
-echo "work dir $WORK_DIR"
 function cleanup {
-	# rm -rf "$WORK_DIR"
-	echo "WORK DIR"
+	rm -rf "$WORK_DIR"
 }
 trap cleanup EXIT
 
 
 export GOPATH="$WORK_DIR"
-
 PKG_PARENT="$WORK_DIR/src/github.com/uber-go"
 PKG_DIR="$PKG_PARENT/atomic"
 
-echo "pkg parent $PKG_PARENT"
-echo "pkg dir $PKG_DIR"
-echo ln -s `pwd` "PKG_DIR"
 mkdir -p "$PKG_PARENT"
 ln -s `pwd` "$PKG_DIR"
 cd "$PKG_DIR"


### PR DESCRIPTION
Fixes #11 

Note: we should add `atomic` to the `go.uber.org` repo first.