### PR TITLE
Fix Go tip errors with self-import

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -18,12 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package atomic
+package atomic_test
 
 import (
 	"fmt"
 
-	atomic "."
+	"go.uber.org/atomic"
 )
 
 func Example() {

--- a/scripts/test-ubergo.sh
+++ b/scripts/test-ubergo.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euox pipefail
 IFS=$'\n\t'
 
 # This script creates a fake GOPATH, symlinks in the current
@@ -21,6 +21,6 @@ cp -R `pwd` "$PKG_DIR"
 cd "$PKG_DIR"
 
 # The example imports go.uber.org, fix the import.
-sed -e 's/go.uber.org\/atomic/github.com\/uber-go\/atomic/' -i '' example_test.go
+sed -e 's/go.uber.org\/atomic/github.com\/uber-go\/atomic/' -i="" example_test.go
 
 make test

--- a/scripts/test-ubergo.sh
+++ b/scripts/test-ubergo.sh
@@ -17,7 +17,10 @@ PKG_PARENT="$WORK_DIR/src/github.com/uber-go"
 PKG_DIR="$PKG_PARENT/atomic"
 
 mkdir -p "$PKG_PARENT"
-ln -s `pwd` "$PKG_DIR"
+cp -R `pwd` "$PKG_DIR"
 cd "$PKG_DIR"
+
+# The example imports go.uber.org, fix the import.
+sed -e 's/go.uber.org\/atomic/github.com\/uber-go\/atomic/' -i '' example_test.go
 
 make test


### PR DESCRIPTION
Go tip does not like `import "atomic" .` which allows us to import the current package as "atomic" without specifying either the `go.uber.org/atomic` or `github.com/uber-go/atomic` package name explicitly.

Instead, we'll use an explicit import path, and have the `test-ubergo.sh` script munge the import.