### PR TITLE
Update Travis to run Go 1.7 and 1.8 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: go
 go_import_path: go.uber.org/atomic
 
 go:
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go_import_path: go.uber.org/atomic
 go:
   - 1.5
   - 1.6
+  - 1.7
+  - 1.8
   - tip
 
 cache:


### PR DESCRIPTION
Before opening your pull request, please make sure that you've:

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

Thanks for your contribution!

There is also an option for Travis called 'allow_failures'.
Am I need to move to update PR to something like this?
```yaml
matrix:
  allow_failures:
    - go: tip
    - go: 1.5
    - go: 1.6
```