### PR TITLE
Use our own Value for String

### DIFF
--- a/string.go
+++ b/string.go
@@ -20,10 +20,8 @@
 
 package atomic
 
-import "sync/atomic"
-
-// String is an atomic type-safe wrapper around atomic.Value for strings.
-type String struct{ v atomic.Value }
+// String is an atomic type-safe wrapper around Value for strings.
+type String struct{ v Value }
 
 // NewString creates a String.
 func NewString(str string) *String {
@@ -44,7 +42,7 @@ func (s *String) Load() string {
 }
 
 // Store atomically stores the passed string.
-// Note: Converting the string to an interface{} to store in the atomic.Value
+// Note: Converting the string to an interface{} to store in the Value
 // requires an allocation.
 func (s *String) Store(str string) {
 	s.v.Store(str)


### PR DESCRIPTION
No change to the emitted code; takes advantage of #19 to simplify.