### PR TITLE
Revert "Optimization for String.Store("")"

### DIFF
--- a/string.go
+++ b/string.go
@@ -45,9 +45,5 @@ func (s *String) Load() string {
 // Note: Converting the string to an interface{} to store in the Value
 // requires an allocation.
 func (s *String) Store(str string) {
-	if str == "" {
-		s.v = Value{}
-		return
-	}
 	s.v.Store(str)
 }

--- a/string_test.go
+++ b/string_test.go
@@ -40,7 +40,4 @@ func TestString(t *testing.T) {
 
 	atom = NewString("bcd")
 	require.Equal(t, "bcd", atom.Load(), "Expected Load to return initialized value")
-
-	atom.Store("")
-	require.Equal(t, "", atom.Load(), "Expected Load to return empty value")
 }


### PR DESCRIPTION
This optimization causes data races since we're changing the value field
without using atomics. E.g., a caller who has multiple goroutines
calling `Set("1")` and `Set("")` will race on the access to `s.v` since
one goroutine is trying to read it while the other sets it, neither
using atomic operations.

This reverts commit 16b44f14f0990d358f2ba3191ff8e7c44c9f0bef.