### PR TITLE
Add parallel benchmarks

### DIFF
--- a/stress_test.go
+++ b/stress_test.go
@@ -69,9 +69,20 @@ func BenchmarkStress(b *testing.B) {
 	for name, ff := range _stressTests {
 		b.Run(name, func(b *testing.B) {
 			f := ff()
-			for i := 0; i < b.N; i++ {
-				f()
-			}
+
+			b.Run("serial", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					f()
+				}
+			})
+
+			b.Run("parallel", func(b *testing.B) {
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						f()
+					}
+				})
+			})
 		})
 	}
 }


### PR DESCRIPTION
Atomic operations tend to be fast when there's no contention but get a
lot slower with contention, so add tests which run the same stress test
in parallel.

Current benchmark results on my laptop:
https://gist.github.com/prashantv/babbdbd9e41b0b04ad29a510be513d79