### PR TITLE
Add standard library atomic operations to benchmark

### DIFF
--- a/stress_test.go
+++ b/stress_test.go
@@ -21,8 +21,10 @@
 package atomic
 
 import (
+	"math"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -32,13 +34,17 @@ const (
 )
 
 var _stressTests = map[string]func() func(){
-	"i32":    stressInt32,
-	"i64":    stressInt64,
-	"u32":    stressUint32,
-	"u64":    stressUint64,
-	"f64":    stressFloat64,
-	"bool":   stressBool,
-	"string": stressString,
+	"i32/std": stressStdInt32,
+	"i32":     stressInt32,
+	"i64/std": stressStdInt32,
+	"i64":     stressInt64,
+	"u32/std": stressStdUint32,
+	"u32":     stressUint32,
+	"u64/std": stressStdUint64,
+	"u64":     stressUint64,
+	"f64":     stressFloat64,
+	"bool":    stressBool,
+	"string":  stressString,
 }
 
 func TestStress(t *testing.T) {
@@ -87,6 +93,20 @@ func BenchmarkStress(b *testing.B) {
 	}
 }
 
+func stressStdInt32() func() {
+	var atom int32
+	return func() {
+		atomic.LoadInt32(&atom)
+		atomic.AddInt32(&atom, 1)
+		atomic.AddInt32(&atom, -2)
+		atomic.AddInt32(&atom, 1)
+		atomic.AddInt32(&atom, -1)
+		atomic.CompareAndSwapInt32(&atom, 1, 0)
+		atomic.SwapInt32(&atom, 5)
+		atomic.StoreInt32(&atom, 1)
+	}
+}
+
 func stressInt32() func() {
 	var atom Int32
 	return func() {
@@ -98,6 +118,20 @@ func stressInt32() func() {
 		atom.CAS(1, 0)
 		atom.Swap(5)
 		atom.Store(1)
+	}
+}
+
+func stressStdInt64() func() {
+	var atom int64
+	return func() {
+		atomic.LoadInt64(&atom)
+		atomic.AddInt64(&atom, 1)
+		atomic.AddInt64(&atom, -2)
+		atomic.AddInt64(&atom, 1)
+		atomic.AddInt64(&atom, -1)
+		atomic.CompareAndSwapInt64(&atom, 1, 0)
+		atomic.SwapInt64(&atom, 5)
+		atomic.StoreInt64(&atom, 1)
 	}
 }
 
@@ -115,6 +149,21 @@ func stressInt64() func() {
 	}
 }
 
+func stressStdUint32() func() {
+	var atom uint32
+	return func() {
+		atomic.LoadUint32(&atom)
+		atomic.AddUint32(&atom, 1)
+		// Adding `MaxUint32` is the same as subtracting 1
+		atomic.AddUint32(&atom, math.MaxUint32-1)
+		atomic.AddUint32(&atom, 1)
+		atomic.AddUint32(&atom, math.MaxUint32)
+		atomic.CompareAndSwapUint32(&atom, 1, 0)
+		atomic.SwapUint32(&atom, 5)
+		atomic.StoreUint32(&atom, 1)
+	}
+}
+
 func stressUint32() func() {
 	var atom Uint32
 	return func() {
@@ -126,6 +175,21 @@ func stressUint32() func() {
 		atom.CAS(1, 0)
 		atom.Swap(5)
 		atom.Store(1)
+	}
+}
+
+func stressStdUint64() func() {
+	var atom uint64
+	return func() {
+		atomic.LoadUint64(&atom)
+		atomic.AddUint64(&atom, 1)
+		// Adding `MaxUint64` is the same as subtracting 1
+		atomic.AddUint64(&atom, math.MaxUint64-1)
+		atomic.AddUint64(&atom, 1)
+		atomic.AddUint64(&atom, math.MaxUint64)
+		atomic.CompareAndSwapUint64(&atom, 1, 0)
+		atomic.SwapUint64(&atom, 5)
+		atomic.StoreUint64(&atom, 1)
 	}
 }
 


### PR DESCRIPTION
Currently, we only benchmark our custom atomic types, but don't
benchmark the standard library types. Add benchmarks for ints and uints
that the standard library supports.

Benchmark results on my machine:
https://gist.github.com/prashantv/4360013d6ec13b16ff983390e5defe73

There's no performance difference between stdlib and the atomic types (thanks to mid-stack inlining), e.g., with i32:
```
BenchmarkStress/i32/std/serial-8                50000000                41.7 ns/op                                    
BenchmarkStress/i32/serial-8                    30000000                41.2 ns/op                                    

BenchmarkStress/i32/std/parallel-8              10000000               174 ns/op                                      
BenchmarkStress/i32/parallel-8                  10000000               176 ns/op                                      
```