### PR TITLE
Add a Go import comment.

### DIFF
--- a/atomic.go
+++ b/atomic.go
@@ -20,7 +20,7 @@
 
 // Package atomic provides simple wrappers around numerics to enforce atomic
 // access.
-package atomic
+package atomic // import "go.uber.org/atomic"
 
 import (
 	"math"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
