### PR TITLE
Change install golint binary import path to golang.org/x/lint/golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install_ci: install
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cmd/cover
 ifdef SHOULD_LINT
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 endif
 
 .PHONY: lint


### PR DESCRIPTION
The lint package has been the hosted in golang.org/x. Fixed failed CI test.

CI result:
  - https://travis-ci.org/uber-go/atomic/jobs/443417746#L491

ref:
  - https://go-review.googlesource.com/c/141457
  - https://go-review.googlesource.com/c/141657

---

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [ ] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).