### PR TITLE
Simplify lint version select, control via .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,13 @@ go:
   - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
   - 1.x # latest release
+
+matrix:
+  include:
+  - go: 1.11.x
+    env: NO_TEST=yes LINT=yes
 
 cache:
   directories:
@@ -17,9 +23,9 @@ install:
   - make install_ci
 
 script:
-  - make test_ci
-  - scripts/test-ubergo.sh
-  - make lint
+  - test -n "$NO_TEST" || make test_ci
+  - test -n "$NO_TEST" || scripts/test-ubergo.sh
+  - test -z "$LINT" || make install_lint lint
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,7 @@ PACKAGES := $(shell glide nv)
 # Many Go tools take file globs or directories as arguments instead of packages.
 PACKAGE_FILES ?= *.go
 
-
-# The linting tools evolve with each Go version, so run them only on the latest
-# stable release.
-GO_VERSION := $(shell go version | cut -d " " -f 3)
-GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 7 8
-ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
-SHOULD_LINT := true
-endif
-
-
+# For pre go1.6
 export GO15VENDOREXPERIMENT=1
 
 
@@ -37,13 +27,14 @@ install_ci: install
 	go get github.com/wadey/gocovmerge
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cmd/cover
-ifdef SHOULD_LINT
-	go get github.com/golang/lint/golint
-endif
+
+.PHONY: install_lint
+install_lint:
+	go get golang.org/x/lint/golint
+
 
 .PHONY: lint
 lint:
-ifdef SHOULD_LINT
 	@rm -rf lint.log
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PACKAGE_FILES) 2>&1 | tee lint.log
@@ -54,9 +45,6 @@ ifdef SHOULD_LINT
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]
-else
-	@echo "Skipping linters on" $(GO_VERSION)
-endif
 
 
 .PHONY: test_ci


### PR DESCRIPTION
This is similar to tchannel, see
https://github.com/uber/tchannel-go/pull/651

and
https://github.com/uber/tchannel-go/blob/dev/.travis.yml

This also pulls in the latest golint package from #45.