### PR TITLE
Run lint on 1.12, remove pre-1.11 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,12 @@ language: go
 go_import_path: go.uber.org/atomic
 
 go:
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
   - 1.11.x
-  - 1.x # latest release
+  - 1.12.x
 
 matrix:
   include:
-  - go: 1.11.x
+  - go: 1.12.x
     env: NO_TEST=yes LINT=yes
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint:
 	@echo "Checking vet..."
 	@go vet ./... 2>&1 | tee -a lint.log;)
 	@echo "Checking lint..."
-	@golint . 2>&1 | tee -a lint.log;)
+	@golint $(go list ./...) 2>&1 | tee -a lint.log;)
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-PACKAGES := $(shell glide nv)
 # Many Go tools take file globs or directories as arguments instead of packages.
 PACKAGE_FILES ?= *.go
 
@@ -8,7 +7,7 @@ export GO15VENDOREXPERIMENT=1
 
 .PHONY: build
 build:
-	go build -i $(PACKAGES)
+	go build -i ./...
 
 
 .PHONY: install
@@ -19,7 +18,7 @@ install:
 
 .PHONY: test
 test:
-	go test -cover -race $(PACKAGES)
+	go test -cover -race ./...
 
 
 .PHONY: install_ci
@@ -39,9 +38,9 @@ lint:
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PACKAGE_FILES) 2>&1 | tee lint.log
 	@echo "Checking vet..."
-	@$(foreach dir,$(PACKAGE_FILES),go tool vet $(dir) 2>&1 | tee -a lint.log;)
+	@go vet ./... 2>&1 | tee -a lint.log;)
 	@echo "Checking lint..."
-	@$(foreach dir,$(PKGS),golint $(dir) 2>&1 | tee -a lint.log;)
+	@golint . 2>&1 | tee -a lint.log;)
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint:
 	@echo "Checking vet..."
 	@go vet ./... 2>&1 | tee -a lint.log;)
 	@echo "Checking lint..."
-	@golint $(go list ./...) 2>&1 | tee -a lint.log;)
+	@golint $$(go list ./...) 2>&1 | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]


### PR DESCRIPTION
Clean up the Makefile to use ./... instead of a packages variable.

Golint checks vendor when used with "./..." so pass in "." explicitly.
This lint check was previously not even running (PKGS was undefined).