### PR TITLE
Support runtime 64 bit alignment for 64 bit atomic instructions on 32 bit architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PACKAGE_FILES ?= *.go
 # For pre go1.6
 export GO15VENDOREXPERIMENT=1
 
+ARCHBITS := $(shell getconf LONG_BIT)
 
 .PHONY: build
 build:
@@ -18,7 +19,11 @@ install:
 
 .PHONY: test
 test:
+ifeq ($(ARCHBITS),64) 
 	go test -cover -race ./...
+else
+	go test -cover ./...
+endif
 
 
 .PHONY: install_ci

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint:
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PACKAGE_FILES) 2>&1 | tee lint.log
 	@echo "Checking vet..."
-	@go vet ./... 2>&1 | tee -a lint.log;)
+	@go vet ./... 2>&1 | tee -a lint.log;
 	@echo "Checking lint..."
 	@golint $$(go list ./...) 2>&1 | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs..."

--- a/atomic.go
+++ b/atomic.go
@@ -84,9 +84,8 @@ func (i *Int64) xAddr() *int64 {
 	// The return must be 8-byte aligned.
 	if uintptr(unsafe.Pointer(&i.v))%8 == 0 {
 		return (*int64)(unsafe.Pointer(&i.v))
-	} else {
-		return (*int64)(unsafe.Pointer(&i.v[1]))
 	}
+	return (*int64)(unsafe.Pointer(&i.v[1]))
 }
 
 // NewInt64 creates an Int64.
@@ -197,9 +196,8 @@ func (i *Uint64) xAddr() *uint64 {
 	// Return pointer to 8-byte aligned address.
 	if uintptr(unsafe.Pointer(&i.v))%8 == 0 {
 		return (*uint64)(unsafe.Pointer(&i.v))
-	} else {
-		return (*uint64)(unsafe.Pointer(&i.v[1]))
 	}
+	return (*uint64)(unsafe.Pointer(&i.v[1]))
 }
 
 // NewUint64 creates a Uint64.


### PR DESCRIPTION
I recently ran into a memory alignment issue when running the jaeger agent on arm32v7:  jaegertracing/jaeger#1656.

 As a first attempt to fix this issue, I reordered the fields in the following structs which were the source of the issue:
```
// peerScore represents a peer and scoring for the peer heap.
// It is not safe for concurrent access, it should only be used through the PeerList.
type peerScore struct {
	*Peer

	// score according to the current peer list's ScoreCalculator.
	score uint64
	// index of the peerScore in the peerHeap. Used to interact with container/heap.
	index int
	// order is the tiebreaker for when score is equal. It is set when a peer
	// is pushed to the heap based on peerHeap.order with jitter.
	order uint64
}

// Peer represents a single autobahn service or client with a unique host:port.
type Peer struct {
	sync.RWMutex

	channel             Connectable
	hostPort            string
	onStatusChanged     func(*Peer)
	onClosedConnRemoved func(*Peer)

	// scCount is the number of subchannels that this peer is added to.
	scCount uint32

	// connections are mutable, and are protected by the mutex.
	newConnLock         sync.Mutex
	inboundConnections  []*Connection
	outboundConnections []*Connection
	chosenCount         atomic.Uint64

	// onUpdate is a test-only hook.
	onUpdate func(*Peer)
}
```

With the embedding of the peer struct within the peerScore struct, a call to \<peerScore\>.chosenCount.Inc() was failing in the atomics library because of memory alignment issues.

I have refactored the atomic operations for Int64 and Uint64 such that 64 bit alignment on 32 bit architectures is guaranteed. 

To do so, for these structs I allocate a 3 item int32 array, then at runtime query which address within this array is 64 bit aligned (address % 8 == 0). It is either going to be the beginning of the array or the address of the first item, and I simply select the properly aligned address to load the 64 int/uint into.