### PR TITLE
Fix typo in make lint rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint:
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PACKAGE_FILES) 2>&1 | tee lint.log
 	@echo "Checking vet..."
-	@go vet ./... 2>&1 | tee -a lint.log;)
+	@go vet ./... 2>&1 | tee -a lint.log
 	@echo "Checking lint..."
 	@golint $$(go list ./...) 2>&1 | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs..."


### PR DESCRIPTION
`make lint` would produce this output on my machine before patch:

```
Checking formatting...
Checking vet...
/bin/sh: -c: line 0: syntax error near unexpected token `)'
/bin/sh: -c: line 0: `go vet ./... 2>&1 | tee -a lint.log;)'
make: *** [lint] Error 2
```

I have no idea how CI was passing with this. Maybe something is broken in a silent way.