### PR TITLE
Support runtime 64 bit alignment for 64 bit atomic instructions on 32 bit architectures

### DIFF
--- a/atomic.go
+++ b/atomic.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"sync/atomic"
 	"time"
+	"unsafe"
 )
 
 // Int32 is an atomic wrapper around an int32.
@@ -77,26 +78,39 @@ func (i *Int32) Swap(n int32) int32 {
 }
 
 // Int64 is an atomic wrapper around an int64.
-type Int64 struct{ v int64 }
+type Int64 struct{ v [3]int32 }
+
+func (i *Int64) xAddr() *int64 {
+	// The return must be 8-byte aligned.
+	if uintptr(unsafe.Pointer(&i.v))%8 == 0 {
+		return (*int64)(unsafe.Pointer(&i.v))
+	}
+	return (*int64)(unsafe.Pointer(&i.v[1]))
+}
 
 // NewInt64 creates an Int64.
 func NewInt64(i int64) *Int64 {
-	return &Int64{i}
+	ret := &Int64{[3]int32{0, 0, 0}}
+	*ret.xAddr() = i
+	return ret
 }
 
 // Load atomically loads the wrapped value.
 func (i *Int64) Load() int64 {
-	return atomic.LoadInt64(&i.v)
+	p := i.xAddr()
+	return atomic.LoadInt64(p)
 }
 
 // Add atomically adds to the wrapped int64 and returns the new value.
 func (i *Int64) Add(n int64) int64 {
-	return atomic.AddInt64(&i.v, n)
+	p := i.xAddr()
+	return atomic.AddInt64(p, n)
 }
 
 // Sub atomically subtracts from the wrapped int64 and returns the new value.
 func (i *Int64) Sub(n int64) int64 {
-	return atomic.AddInt64(&i.v, -n)
+	p := i.xAddr()
+	return atomic.AddInt64(p, -n)
 }
 
 // Inc atomically increments the wrapped int64 and returns the new value.
@@ -111,17 +125,20 @@ func (i *Int64) Dec() int64 {
 
 // CAS is an atomic compare-and-swap.
 func (i *Int64) CAS(old, new int64) bool {
-	return atomic.CompareAndSwapInt64(&i.v, old, new)
+	p := i.xAddr()
+	return atomic.CompareAndSwapInt64(p, old, new)
 }
 
 // Store atomically stores the passed value.
 func (i *Int64) Store(n int64) {
-	atomic.StoreInt64(&i.v, n)
+	p := i.xAddr()
+	atomic.StoreInt64(p, n)
 }
 
 // Swap atomically swaps the wrapped int64 and returns the old value.
 func (i *Int64) Swap(n int64) int64 {
-	return atomic.SwapInt64(&i.v, n)
+	p := i.xAddr()
+	return atomic.SwapInt64(p, n)
 }
 
 // Uint32 is an atomic wrapper around an uint32.
@@ -173,26 +190,39 @@ func (i *Uint32) Swap(n uint32) uint32 {
 }
 
 // Uint64 is an atomic wrapper around a uint64.
-type Uint64 struct{ v uint64 }
+type Uint64 struct{ v [3]int32 }
+
+func (i *Uint64) xAddr() *uint64 {
+	// Return pointer to 8-byte aligned address.
+	if uintptr(unsafe.Pointer(&i.v))%8 == 0 {
+		return (*uint64)(unsafe.Pointer(&i.v))
+	}
+	return (*uint64)(unsafe.Pointer(&i.v[1]))
+}
 
 // NewUint64 creates a Uint64.
 func NewUint64(i uint64) *Uint64 {
-	return &Uint64{i}
+	ret := &Uint64{[3]int32{0, 0, 0}}
+	*ret.xAddr() = i
+	return ret
 }
 
 // Load atomically loads the wrapped value.
 func (i *Uint64) Load() uint64 {
-	return atomic.LoadUint64(&i.v)
+	p := i.xAddr()
+	return atomic.LoadUint64(p)
 }
 
 // Add atomically adds to the wrapped uint64 and returns the new value.
 func (i *Uint64) Add(n uint64) uint64 {
-	return atomic.AddUint64(&i.v, n)
+	p := i.xAddr()
+	return atomic.AddUint64(p, n)
 }
 
 // Sub atomically subtracts from the wrapped uint64 and returns the new value.
 func (i *Uint64) Sub(n uint64) uint64 {
-	return atomic.AddUint64(&i.v, ^(n - 1))
+	p := i.xAddr()
+	return atomic.AddUint64(p, ^(n - 1))
 }
 
 // Inc atomically increments the wrapped uint64 and returns the new value.
@@ -207,17 +237,20 @@ func (i *Uint64) Dec() uint64 {
 
 // CAS is an atomic compare-and-swap.
 func (i *Uint64) CAS(old, new uint64) bool {
-	return atomic.CompareAndSwapUint64(&i.v, old, new)
+	p := i.xAddr()
+	return atomic.CompareAndSwapUint64(p, old, new)
 }
 
 // Store atomically stores the passed value.
 func (i *Uint64) Store(n uint64) {
-	atomic.StoreUint64(&i.v, n)
+	p := i.xAddr()
+	atomic.StoreUint64(p, n)
 }
 
 // Swap atomically swaps the wrapped uint64 and returns the old value.
 func (i *Uint64) Swap(n uint64) uint64 {
-	return atomic.SwapUint64(&i.v, n)
+	p := i.xAddr()
+	return atomic.SwapUint64(p, n)
 }
 
 // Bool is an atomic Boolean.
@@ -313,12 +346,12 @@ func (f *Float64) CAS(old, new float64) bool {
 // Duration is an atomic wrapper around time.Duration
 // https://godoc.org/time#Duration
 type Duration struct {
-	v Int64
+	v *Int64
 }
 
 // NewDuration creates a Duration.
 func NewDuration(d time.Duration) *Duration {
-	return &Duration{v: *NewInt64(int64(d))}
+	return &Duration{v: NewInt64(int64(d))}
 }
 
 // Load atomically loads the wrapped value.


### PR DESCRIPTION
I recently ran into a memory alignment issue when running the jaeger agent on arm32v7: jaegertracing/jaeger#1656.

As a first attempt to fix this issue, I reordered the fields in the following structs which were the source of the issue:
```
// peerScore represents a peer and scoring for the peer heap.
// It is not safe for concurrent access, it should only be used through the PeerList.
type peerScore struct {
	*Peer

	// score according to the current peer list's ScoreCalculator.
	score uint64
	// index of the peerScore in the peerHeap. Used to interact with container/heap.
	index int
	// order is the tiebreaker for when score is equal. It is set when a peer
	// is pushed to the heap based on peerHeap.order with jitter.
	order uint64
}
```
```
// Peer represents a single autobahn service or client with a unique host:port.
type Peer struct {
	sync.RWMutex

	channel             Connectable
	hostPort            string
	onStatusChanged     func(*Peer)
	onClosedConnRemoved func(*Peer)

	// scCount is the number of subchannels that this peer is added to.
	scCount uint32

	// connections are mutable, and are protected by the mutex.
	newConnLock         sync.Mutex
	inboundConnections  []*Connection
	outboundConnections []*Connection
	chosenCount         atomic.Uint64

	// onUpdate is a test-only hook.
	onUpdate func(*Peer)
}
```
With the embedding of the peer struct within the peerScore struct, a call to \<peerScore\>.chosenCount.Inc() was failing in the atomics library because of memory alignment issues.

I have refactored the atomic operations for Int64 and Uint64 such that 64 bit alignment on 32 bit architectures is guaranteed.

To do so, for these structs I allocate a 3 item int32 array, then at runtime query which address within this array is 64 bit aligned (address % 8 == 0). It is either going to be the beginning of the array or the address of the first item, and I simply select the properly aligned address to load the 64 int/uint into.