### PR TITLE
Add JSON Marshal and Unmarshal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 
 matrix:
   include:
-  - go: 1.12.x
-  - go: 1.13.x
+  - go: oldstable
+  - go: stable
     env: LINT=1
 
 cache:

--- a/atomic.go
+++ b/atomic.go
@@ -85,8 +85,7 @@ func (i *Int32) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON allows for json decoding of the wrapped int32
 func (i *Int32) UnmarshalJSON(b []byte) error {
 	var v int32
-	err := json.Unmarshal(b, &v)
-	if err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	i.Store(v)
@@ -149,8 +148,7 @@ func (i *Int64) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON allows for json decoding of the wrapped int64
 func (i *Int64) UnmarshalJSON(b []byte) error {
 	var v int64
-	err := json.Unmarshal(b, &v)
-	if err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	i.Store(v)
@@ -213,8 +211,7 @@ func (i *Uint32) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON allows for json decoding of the wrapped uint32
 func (i *Uint32) UnmarshalJSON(b []byte) error {
 	var v uint32
-	err := json.Unmarshal(b, &v)
-	if err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	i.Store(v)
@@ -277,8 +274,7 @@ func (i *Uint64) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON allows for json decoding of the wrapped uint64
 func (i *Uint64) UnmarshalJSON(b []byte) error {
 	var v uint64
-	err := json.Unmarshal(b, &v)
-	if err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	i.Store(v)
@@ -334,16 +330,15 @@ func boolToInt(b bool) uint32 {
 	return 0
 }
 
-// MarshalJSON allows for json encoding of the wrapped float64
+// MarshalJSON allows for json encoding of the wrapped bool
 func (b *Bool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.Load())
 }
 
-// UnmarshalJSON allows for json decoding of the wrapped float64
+// UnmarshalJSON allows for json decoding of the wrapped bool
 func (b *Bool) UnmarshalJSON(t []byte) error {
 	var v bool
-	err := json.Unmarshal(t, &v)
-	if err != nil {
+	if err := json.Unmarshal(t, &v); err != nil {
 		return err
 	}
 	b.Store(v)
@@ -399,8 +394,7 @@ func (f *Float64) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON allows for json decoding of the wrapped float64
 func (f *Float64) UnmarshalJSON(b []byte) error {
 	var v float64
-	err := json.Unmarshal(b, &v)
-	if err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	f.Store(v)

--- a/atomic.go
+++ b/atomic.go
@@ -24,7 +24,6 @@ package atomic
 
 import (
 	"encoding/json"
-	"errors"
 	"math"
 	"sync/atomic"
 	"time"

--- a/atomic.go
+++ b/atomic.go
@@ -24,6 +24,7 @@ package atomic
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"sync/atomic"
 	"time"

--- a/atomic.go
+++ b/atomic.go
@@ -442,6 +442,21 @@ func (d *Duration) CAS(old, new time.Duration) bool {
 	return d.v.CAS(int64(old), int64(new))
 }
 
+// MarshalJSON encodes the wrapped time.Duration into JSON.
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Load())
+}
+
+// UnmarshalJSON decodes JSON into the wrapped time.Duration.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v time.Duration
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	d.Store(v)
+	return nil
+}
+
 // Value shadows the type of the same name from sync/atomic
 // https://godoc.org/sync/atomic#Value
 type Value struct{ atomic.Value }

--- a/atomic.go
+++ b/atomic.go
@@ -23,6 +23,7 @@
 package atomic
 
 import (
+	"encoding/json"
 	"math"
 	"sync/atomic"
 	"time"
@@ -76,6 +77,22 @@ func (i *Int32) Swap(n int32) int32 {
 	return atomic.SwapInt32(&i.v, n)
 }
 
+// MarshalJSON allows for json encoding of the wrapped int32
+func (i *Int32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.Load())
+}
+
+// UnmarshalJSON allows for json decoding of the wrapped int32
+func (i *Int32) UnmarshalJSON(b []byte) error {
+	var v int32
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	i.Store(v)
+	return nil
+}
+
 // Int64 is an atomic wrapper around an int64.
 type Int64 struct{ v int64 }
 
@@ -122,6 +139,22 @@ func (i *Int64) Store(n int64) {
 // Swap atomically swaps the wrapped int64 and returns the old value.
 func (i *Int64) Swap(n int64) int64 {
 	return atomic.SwapInt64(&i.v, n)
+}
+
+// MarshalJSON allows for json encoding of the wrapped int64
+func (i *Int64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.Load())
+}
+
+// UnmarshalJSON allows for json decoding of the wrapped int64
+func (i *Int64) UnmarshalJSON(b []byte) error {
+	var v int64
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	i.Store(v)
+	return nil
 }
 
 // Uint32 is an atomic wrapper around an uint32.
@@ -172,6 +205,22 @@ func (i *Uint32) Swap(n uint32) uint32 {
 	return atomic.SwapUint32(&i.v, n)
 }
 
+// MarshalJSON allows for json encoding of the wrapped uint32
+func (i *Uint32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.Load())
+}
+
+// UnmarshalJSON allows for json decoding of the wrapped uint32
+func (i *Uint32) UnmarshalJSON(b []byte) error {
+	var v uint32
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	i.Store(v)
+	return nil
+}
+
 // Uint64 is an atomic wrapper around a uint64.
 type Uint64 struct{ v uint64 }
 
@@ -218,6 +267,22 @@ func (i *Uint64) Store(n uint64) {
 // Swap atomically swaps the wrapped uint64 and returns the old value.
 func (i *Uint64) Swap(n uint64) uint64 {
 	return atomic.SwapUint64(&i.v, n)
+}
+
+// MarshalJSON allows for json encoding of the wrapped uint64
+func (i *Uint64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.Load())
+}
+
+// UnmarshalJSON allows for json decoding of the wrapped uint64
+func (i *Uint64) UnmarshalJSON(b []byte) error {
+	var v uint64
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	i.Store(v)
+	return nil
 }
 
 // Bool is an atomic Boolean.
@@ -269,6 +334,22 @@ func boolToInt(b bool) uint32 {
 	return 0
 }
 
+// MarshalJSON allows for json encoding of the wrapped float64
+func (b *Bool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.Load())
+}
+
+// UnmarshalJSON allows for json decoding of the wrapped float64
+func (b *Bool) UnmarshalJSON(t []byte) error {
+	var v bool
+	err := json.Unmarshal(t, &v)
+	if err != nil {
+		return err
+	}
+	b.Store(v)
+	return nil
+}
+
 // Float64 is an atomic wrapper around float64.
 type Float64 struct {
 	v uint64
@@ -308,6 +389,22 @@ func (f *Float64) Sub(s float64) float64 {
 // CAS is an atomic compare-and-swap.
 func (f *Float64) CAS(old, new float64) bool {
 	return atomic.CompareAndSwapUint64(&f.v, math.Float64bits(old), math.Float64bits(new))
+}
+
+// MarshalJSON allows for json encoding of the wrapped float64
+func (f *Float64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.Load())
+}
+
+// UnmarshalJSON allows for json decoding of the wrapped float64
+func (f *Float64) UnmarshalJSON(b []byte) error {
+	var v float64
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	f.Store(v)
+	return nil
 }
 
 // Duration is an atomic wrapper around time.Duration

--- a/atomic.go
+++ b/atomic.go
@@ -77,12 +77,12 @@ func (i *Int32) Swap(n int32) int32 {
 	return atomic.SwapInt32(&i.v, n)
 }
 
-// MarshalJSON allows for json encoding of the wrapped int32
+// MarshalJSON encodes the wrapped int32 into JSON.
 func (i *Int32) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.Load())
 }
 
-// UnmarshalJSON allows for json decoding of the wrapped int32
+// UnmarshalJSON decodes JSON into the wrapped int32.
 func (i *Int32) UnmarshalJSON(b []byte) error {
 	var v int32
 	if err := json.Unmarshal(b, &v); err != nil {
@@ -140,12 +140,12 @@ func (i *Int64) Swap(n int64) int64 {
 	return atomic.SwapInt64(&i.v, n)
 }
 
-// MarshalJSON allows for json encoding of the wrapped int64
+// MarshalJSON encodes the wrapped int64 into JSON.
 func (i *Int64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.Load())
 }
 
-// UnmarshalJSON allows for json decoding of the wrapped int64
+// UnmarshalJSON decodes JSON into the wrapped int64.
 func (i *Int64) UnmarshalJSON(b []byte) error {
 	var v int64
 	if err := json.Unmarshal(b, &v); err != nil {
@@ -203,12 +203,12 @@ func (i *Uint32) Swap(n uint32) uint32 {
 	return atomic.SwapUint32(&i.v, n)
 }
 
-// MarshalJSON allows for json encoding of the wrapped uint32
+// MarshalJSON encodes the wrapped uint32 into JSON.
 func (i *Uint32) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.Load())
 }
 
-// UnmarshalJSON allows for json decoding of the wrapped uint32
+// UnmarshalJSON decodes JSON into the wrapped uint32.
 func (i *Uint32) UnmarshalJSON(b []byte) error {
 	var v uint32
 	if err := json.Unmarshal(b, &v); err != nil {
@@ -266,12 +266,12 @@ func (i *Uint64) Swap(n uint64) uint64 {
 	return atomic.SwapUint64(&i.v, n)
 }
 
-// MarshalJSON allows for json encoding of the wrapped uint64
+// MarshalJSON encodes the wrapped uint64 into JSON.
 func (i *Uint64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.Load())
 }
 
-// UnmarshalJSON allows for json decoding of the wrapped uint64
+// UnmarshalJSON decodes JSON into the wrapped uint64.
 func (i *Uint64) UnmarshalJSON(b []byte) error {
 	var v uint64
 	if err := json.Unmarshal(b, &v); err != nil {
@@ -330,12 +330,12 @@ func boolToInt(b bool) uint32 {
 	return 0
 }
 
-// MarshalJSON allows for json encoding of the wrapped bool
+// MarshalJSON encodes the wrapped bool into JSON.
 func (b *Bool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.Load())
 }
 
-// UnmarshalJSON allows for json decoding of the wrapped bool
+// UnmarshalJSON decodes JSON into the wrapped bool.
 func (b *Bool) UnmarshalJSON(t []byte) error {
 	var v bool
 	if err := json.Unmarshal(t, &v); err != nil {
@@ -386,12 +386,12 @@ func (f *Float64) CAS(old, new float64) bool {
 	return atomic.CompareAndSwapUint64(&f.v, math.Float64bits(old), math.Float64bits(new))
 }
 
-// MarshalJSON allows for json encoding of the wrapped float64
+// MarshalJSON encodes the wrapped float64 into JSON.
 func (f *Float64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.Load())
 }
 
-// UnmarshalJSON allows for json decoding of the wrapped float64
+// UnmarshalJSON decodes JSON into the wrapped float64.
 func (f *Float64) UnmarshalJSON(b []byte) error {
 	var v float64
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -21,7 +21,7 @@
 package atomic
 
 import (
-	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -21,7 +21,7 @@
 package atomic
 
 import (
-	"encoding/json
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -21,6 +21,7 @@
 package atomic
 
 import (
+	"encoding/json
 	"errors"
 	"testing"
 	"time"

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -49,13 +49,13 @@ func TestInt32(t *testing.T) {
 
 	bytes, err := json.Marshal(atom)
 	require.Nil(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
-	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	err = json.Unmarshal([]byte("40"), &atom)
 	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, int32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
-	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int32",
 		"json.Unmarshal didn't error with the expected error message.")
@@ -81,13 +81,13 @@ func TestInt64(t *testing.T) {
 
 	bytes, err := json.Marshal(atom)
 	require.Nil(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
-	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	err = json.Unmarshal([]byte("40"), &atom)
 	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, int64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
-	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int64",
 		"json.Unmarshal didn't error with the expected error message.")
@@ -113,13 +113,13 @@ func TestUint32(t *testing.T) {
 
 	bytes, err := json.Marshal(atom)
 	require.Nil(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
-	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	err = json.Unmarshal([]byte("40"), &atom)
 	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, uint32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
-	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint32",
 		"json.Unmarshal didn't error with the expected error message.")
@@ -145,13 +145,13 @@ func TestUint64(t *testing.T) {
 
 	bytes, err := json.Marshal(atom)
 	require.Nil(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
-	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	err = json.Unmarshal([]byte("40"), &atom)
 	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, uint64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
-	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint64",
 		"json.Unmarshal didn't error with the expected error message.")
@@ -183,13 +183,13 @@ func TestBool(t *testing.T) {
 	atom.Store(true)
 	bytes, err := json.Marshal(atom)
 	require.Nil(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte{'t', 'r', 'u', 'e'}, bytes, "json.Marshal encoded the wrong bytes.")
+	require.Equal(t, []byte("true"), bytes, "json.Marshal encoded the wrong bytes.")
 
-	err = json.Unmarshal([]byte{'f', 'a', 'l', 's', 'e'}, &atom)
+	err = json.Unmarshal([]byte("false"), &atom)
 	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
 	require.False(t, atom.Load(), "json.Unmarshal didn't set the correct value.")
 
-	err = json.Unmarshal([]byte{'4', '2'}, &atom)
+	err = json.Unmarshal([]byte("42"), &atom)
 	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal number into Go value of type bool",
 		"json.Unmarshal didn't error with the expected error message.")
@@ -212,13 +212,13 @@ func TestFloat64(t *testing.T) {
 	atom.Store(42.5)
 	bytes, err := json.Marshal(atom)
 	require.Nil(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte{'4', '2', '.', '5'}, bytes, "json.Marshal encoded the wrong bytes.")
+	require.Equal(t, []byte("42.5"), bytes, "json.Marshal encoded the wrong bytes.")
 
-	err = json.Unmarshal([]byte{'4', '0', '.', '5'}, &atom)
+	err = json.Unmarshal([]byte("40.5"), &atom)
 	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, float64(40.5), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
-	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	err = json.Unmarshal([]byte("\"40.5\""), &atom)
 	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type float64", "json.Unmarshal didn't error with the expected error message.")
 }

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -48,11 +48,11 @@ func TestInt32(t *testing.T) {
 	require.Equal(t, int32(42), atom.Load(), "Store didn't set the correct value.")
 
 	bytes, err := json.Marshal(atom)
-	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
 	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
 	err = json.Unmarshal([]byte("40"), &atom)
-	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, int32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
@@ -80,11 +80,11 @@ func TestInt64(t *testing.T) {
 	require.Equal(t, int64(42), atom.Load(), "Store didn't set the correct value.")
 
 	bytes, err := json.Marshal(atom)
-	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
 	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
 	err = json.Unmarshal([]byte("40"), &atom)
-	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, int64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
@@ -112,11 +112,11 @@ func TestUint32(t *testing.T) {
 	require.Equal(t, uint32(42), atom.Load(), "Store didn't set the correct value.")
 
 	bytes, err := json.Marshal(atom)
-	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
 	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
 	err = json.Unmarshal([]byte("40"), &atom)
-	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, uint32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
@@ -144,11 +144,11 @@ func TestUint64(t *testing.T) {
 	require.Equal(t, uint64(42), atom.Load(), "Store didn't set the correct value.")
 
 	bytes, err := json.Marshal(atom)
-	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
 	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
 
 	err = json.Unmarshal([]byte("40"), &atom)
-	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, uint64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
@@ -182,11 +182,11 @@ func TestBool(t *testing.T) {
 
 	atom.Store(true)
 	bytes, err := json.Marshal(atom)
-	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
 	require.Equal(t, []byte("true"), bytes, "json.Marshal encoded the wrong bytes.")
 
 	err = json.Unmarshal([]byte("false"), &atom)
-	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
 	require.False(t, atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("42"), &atom)
@@ -211,11 +211,11 @@ func TestFloat64(t *testing.T) {
 
 	atom.Store(42.5)
 	bytes, err := json.Marshal(atom)
-	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
 	require.Equal(t, []byte("42.5"), bytes, "json.Marshal encoded the wrong bytes.")
 
 	err = json.Unmarshal([]byte("40.5"), &atom)
-	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
 	require.Equal(t, float64(40.5), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40.5\""), &atom)

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -57,8 +57,8 @@ func TestInt32(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int32",
-		"json.Unmarshal didn't error with the expected error message.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
 func TestInt64(t *testing.T) {
@@ -89,8 +89,8 @@ func TestInt64(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int64",
-		"json.Unmarshal didn't error with the expected error message.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
 func TestUint32(t *testing.T) {
@@ -121,8 +121,8 @@ func TestUint32(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint32",
-		"json.Unmarshal didn't error with the expected error message.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
 func TestUint64(t *testing.T) {
@@ -153,8 +153,8 @@ func TestUint64(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint64",
-		"json.Unmarshal didn't error with the expected error message.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
 func TestBool(t *testing.T) {
@@ -191,8 +191,8 @@ func TestBool(t *testing.T) {
 
 	err = json.Unmarshal([]byte("42"), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.Equal(t, err.Error(), "json: cannot unmarshal number into Go value of type bool",
-		"json.Unmarshal didn't error with the expected error message.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
 func TestFloat64(t *testing.T) {
@@ -220,7 +220,8 @@ func TestFloat64(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40.5\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type float64", "json.Unmarshal didn't error with the expected error message.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
 func TestDuration(t *testing.T) {

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -240,6 +240,20 @@ func TestDuration(t *testing.T) {
 
 	atom.Store(10 * time.Minute)
 	require.Equal(t, 10*time.Minute, atom.Load(), "Store didn't set the correct value.")
+
+	atom.Store(time.Second)
+    bytes, err := json.Marshal(atom)
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte("1000000000"), bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte("1000000000"), &atom)
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+	require.Equal(t, time.Second, atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte("\"1000000000\""), &atom)
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
 func TestValue(t *testing.T) {

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -56,7 +56,7 @@ func TestInt32(t *testing.T) {
 	require.Equal(t, int32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int32",
 		"json.Unmarshal didn't error with the expected error message.")
 }
@@ -88,7 +88,7 @@ func TestInt64(t *testing.T) {
 	require.Equal(t, int64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int64",
 		"json.Unmarshal didn't error with the expected error message.")
 }
@@ -120,7 +120,7 @@ func TestUint32(t *testing.T) {
 	require.Equal(t, uint32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint32",
 		"json.Unmarshal didn't error with the expected error message.")
 }
@@ -152,7 +152,7 @@ func TestUint64(t *testing.T) {
 	require.Equal(t, uint64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint64",
 		"json.Unmarshal didn't error with the expected error message.")
 }
@@ -190,7 +190,7 @@ func TestBool(t *testing.T) {
 	require.False(t, atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("42"), &atom)
-	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal number into Go value of type bool",
 		"json.Unmarshal didn't error with the expected error message.")
 }
@@ -219,7 +219,7 @@ func TestFloat64(t *testing.T) {
 	require.Equal(t, float64(40.5), atom.Load(), "json.Unmarshal didn't set the correct value.")
 
 	err = json.Unmarshal([]byte("\"40.5\""), &atom)
-	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type float64", "json.Unmarshal didn't error with the expected error message.")
 }
 

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -242,7 +242,7 @@ func TestDuration(t *testing.T) {
 	require.Equal(t, 10*time.Minute, atom.Load(), "Store didn't set the correct value.")
 
 	atom.Store(time.Second)
-    bytes, err := json.Marshal(atom)
+	bytes, err := json.Marshal(atom)
 	require.NoError(t, err, "json.Marshal errored unexpectedly.")
 	require.Equal(t, []byte("1000000000"), bytes, "json.Marshal encoded the wrong bytes.")
 

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -21,6 +21,7 @@
 package atomic
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -45,6 +46,19 @@ func TestInt32(t *testing.T) {
 
 	atom.Store(42)
 	require.Equal(t, int32(42), atom.Load(), "Store didn't set the correct value.")
+
+	bytes, err := json.Marshal(atom)
+	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.Equal(t, int32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int32",
+		"json.Unmarshal didn't error with the expected error message.")
 }
 
 func TestInt64(t *testing.T) {
@@ -64,6 +78,19 @@ func TestInt64(t *testing.T) {
 
 	atom.Store(42)
 	require.Equal(t, int64(42), atom.Load(), "Store didn't set the correct value.")
+
+	bytes, err := json.Marshal(atom)
+	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.Equal(t, int64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type int64",
+		"json.Unmarshal didn't error with the expected error message.")
 }
 
 func TestUint32(t *testing.T) {
@@ -83,6 +110,19 @@ func TestUint32(t *testing.T) {
 
 	atom.Store(42)
 	require.Equal(t, uint32(42), atom.Load(), "Store didn't set the correct value.")
+
+	bytes, err := json.Marshal(atom)
+	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.Equal(t, uint32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint32",
+		"json.Unmarshal didn't error with the expected error message.")
 }
 
 func TestUint64(t *testing.T) {
@@ -102,6 +142,19 @@ func TestUint64(t *testing.T) {
 
 	atom.Store(42)
 	require.Equal(t, uint64(42), atom.Load(), "Store didn't set the correct value.")
+
+	bytes, err := json.Marshal(atom)
+	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte{'4', '2'}, bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte{'4', '0'}, &atom)
+	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.Equal(t, uint64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type uint64",
+		"json.Unmarshal didn't error with the expected error message.")
 }
 
 func TestBool(t *testing.T) {
@@ -126,6 +179,20 @@ func TestBool(t *testing.T) {
 
 	prev = atom.Swap(true)
 	require.False(t, prev, "Expected Swap to return previous value.")
+
+	atom.Store(true)
+	bytes, err := json.Marshal(atom)
+	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte{'t', 'r', 'u', 'e'}, bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte{'f', 'a', 'l', 's', 'e'}, &atom)
+	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.False(t, atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte{'4', '2'}, &atom)
+	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Equal(t, err.Error(), "json: cannot unmarshal number into Go value of type bool",
+		"json.Unmarshal didn't error with the expected error message.")
 }
 
 func TestFloat64(t *testing.T) {
@@ -141,6 +208,19 @@ func TestFloat64(t *testing.T) {
 	require.Equal(t, float64(42.0), atom.Load(), "Store didn't set the correct value.")
 	require.Equal(t, float64(42.5), atom.Add(0.5), "Add didn't work.")
 	require.Equal(t, float64(42.0), atom.Sub(0.5), "Sub didn't work.")
+
+	atom.Store(42.5)
+	bytes, err := json.Marshal(atom)
+	require.Nil(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte{'4', '2', '.', '5'}, bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte{'4', '0', '.', '5'}, &atom)
+	require.Nil(t, err, "json.Unmarshal errored unexpectedly.")
+	require.Equal(t, float64(40.5), atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte{'"', '4', '0', '"'}, &atom)
+	require.NotNil(t, err, "json.Unmarshal didn't error as expected.")
+	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type float64", "json.Unmarshal didn't error with the expected error message.")
 }
 
 func TestDuration(t *testing.T) {

--- a/string.go
+++ b/string.go
@@ -20,6 +20,10 @@
 
 package atomic
 
+import (
+	"encoding/json"
+)
+
 // String is an atomic type-safe wrapper around Value for strings.
 type String struct{ v Value }
 
@@ -39,6 +43,21 @@ func (s *String) Load() string {
 		return ""
 	}
 	return v.(string)
+}
+
+// MarshalJSON encodes the wrapped string into JSON.
+func (s *String) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.Load())
+}
+
+// UnmarshalJSON decodes JSON into the wrapped string.
+func (s *String) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	s.Store(v)
+	return nil
 }
 
 // Store atomically stores the passed string.

--- a/string_test.go
+++ b/string_test.go
@@ -21,6 +21,8 @@
 package atomic
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,4 +42,17 @@ func TestString(t *testing.T) {
 
 	atom = NewString("bcd")
 	require.Equal(t, "bcd", atom.Load(), "Expected Load to return initialized value")
+
+	bytes, err := json.Marshal(atom)
+	require.NoError(t, err, "json.Marshal errored unexpectedly.")
+	require.Equal(t, []byte("\"bcd\""), bytes, "json.Marshal encoded the wrong bytes.")
+
+	err = json.Unmarshal([]byte("\"abc\""), &atom)
+	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+	require.Equal(t, "abc", atom.Load(), "json.Unmarshal didn't set the correct value.")
+
+	err = json.Unmarshal([]byte("42"), &atom)
+	require.Error(t, err, "json.Unmarshal didn't error as expected.")
+	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }


### PR DESCRIPTION
Allows for atomic objects within structs to be marshaled/unmarshaled as expected. Currently, marshaling returns an "{}".

This also completes issue #49 

- [ ] updated the changelog if the change is user-facing;
- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).
