### PR TITLE
Tests: Use subtests for JSON

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package atomic
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Marks the test as failed if the error cannot be cast into the provided type
+// with errors.As.
+//
+//   assertErrorAsType(t, err, new(ErrFoo))
+func assertErrorAsType(t *testing.T, err error, typ interface{}, msgAndArgs ...interface{}) bool {
+	t.Helper()
+
+	return assert.True(t, errors.As(err, typ), msgAndArgs...)
+}
+
+func assertErrorJSONUnmarshalType(t *testing.T, err error, msgAndArgs ...interface{}) bool {
+	t.Helper()
+
+	return assertErrorAsType(t, err, new(*json.UnmarshalTypeError), msgAndArgs...)
+}

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2016-2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@ package atomic
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 	"time"
 
@@ -58,7 +57,7 @@ func TestInt32(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
@@ -90,7 +89,7 @@ func TestInt64(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
@@ -122,7 +121,7 @@ func TestUint32(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
@@ -154,7 +153,7 @@ func TestUint64(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
@@ -192,7 +191,7 @@ func TestBool(t *testing.T) {
 
 	err = json.Unmarshal([]byte("42"), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
@@ -221,7 +220,7 @@ func TestFloat64(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"40.5\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 
@@ -252,7 +251,7 @@ func TestDuration(t *testing.T) {
 
 	err = json.Unmarshal([]byte("\"1000000000\""), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }
 

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -47,18 +47,24 @@ func TestInt32(t *testing.T) {
 	atom.Store(42)
 	require.Equal(t, int32(42), atom.Load(), "Store didn't set the correct value.")
 
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("40"), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.Equal(t, int32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("40"), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.Equal(t, int32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("\"40\""), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }
 
 func TestInt64(t *testing.T) {
@@ -79,18 +85,24 @@ func TestInt64(t *testing.T) {
 	atom.Store(42)
 	require.Equal(t, int64(42), atom.Load(), "Store didn't set the correct value.")
 
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("40"), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.Equal(t, int64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("40"), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.Equal(t, int64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("\"40\""), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }
 
 func TestUint32(t *testing.T) {
@@ -111,18 +123,24 @@ func TestUint32(t *testing.T) {
 	atom.Store(42)
 	require.Equal(t, uint32(42), atom.Load(), "Store didn't set the correct value.")
 
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("40"), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.Equal(t, uint32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("40"), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.Equal(t, uint32(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("\"40\""), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }
 
 func TestUint64(t *testing.T) {
@@ -143,18 +161,24 @@ func TestUint64(t *testing.T) {
 	atom.Store(42)
 	require.Equal(t, uint64(42), atom.Load(), "Store didn't set the correct value.")
 
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("42"), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("40"), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.Equal(t, uint64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("40"), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.Equal(t, uint64(40), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("\"40\""), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("\"40\""), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }
 
 func TestBool(t *testing.T) {
@@ -180,19 +204,25 @@ func TestBool(t *testing.T) {
 	prev = atom.Swap(true)
 	require.False(t, prev, "Expected Swap to return previous value.")
 
-	atom.Store(true)
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("true"), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		atom.Store(true)
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("true"), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("false"), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.False(t, atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("false"), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.False(t, atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("42"), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("42"), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }
 
 func TestFloat64(t *testing.T) {
@@ -209,19 +239,25 @@ func TestFloat64(t *testing.T) {
 	require.Equal(t, float64(42.5), atom.Add(0.5), "Add didn't work.")
 	require.Equal(t, float64(42.0), atom.Sub(0.5), "Sub didn't work.")
 
-	atom.Store(42.5)
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("42.5"), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		atom.Store(42.5)
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("42.5"), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("40.5"), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.Equal(t, float64(40.5), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("40.5"), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.Equal(t, float64(40.5), atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("\"40.5\""), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("\"40.5\""), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }
 
 func TestDuration(t *testing.T) {
@@ -240,19 +276,25 @@ func TestDuration(t *testing.T) {
 	atom.Store(10 * time.Minute)
 	require.Equal(t, 10*time.Minute, atom.Load(), "Store didn't set the correct value.")
 
-	atom.Store(time.Second)
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("1000000000"), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		atom.Store(time.Second)
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("1000000000"), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("1000000000"), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.Equal(t, time.Second, atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("1000000000"), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.Equal(t, time.Second, atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("\"1000000000\""), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("\"1000000000\""), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }
 
 func TestValue(t *testing.T) {

--- a/string_test.go
+++ b/string_test.go
@@ -42,16 +42,22 @@ func TestString(t *testing.T) {
 	atom = NewString("bcd")
 	require.Equal(t, "bcd", atom.Load(), "Expected Load to return initialized value")
 
-	bytes, err := json.Marshal(atom)
-	require.NoError(t, err, "json.Marshal errored unexpectedly.")
-	require.Equal(t, []byte("\"bcd\""), bytes, "json.Marshal encoded the wrong bytes.")
+	t.Run("JSON/Marshal", func(t *testing.T) {
+		bytes, err := json.Marshal(atom)
+		require.NoError(t, err, "json.Marshal errored unexpectedly.")
+		require.Equal(t, []byte("\"bcd\""), bytes, "json.Marshal encoded the wrong bytes.")
+	})
 
-	err = json.Unmarshal([]byte("\"abc\""), &atom)
-	require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
-	require.Equal(t, "abc", atom.Load(), "json.Unmarshal didn't set the correct value.")
+	t.Run("JSON/Unmarshal", func(t *testing.T) {
+		err := json.Unmarshal([]byte("\"abc\""), &atom)
+		require.NoError(t, err, "json.Unmarshal errored unexpectedly.")
+		require.Equal(t, "abc", atom.Load(), "json.Unmarshal didn't set the correct value.")
+	})
 
-	err = json.Unmarshal([]byte("42"), &atom)
-	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	assertErrorJSONUnmarshalType(t, err,
-		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	t.Run("JSON/Unmarshal/Error", func(t *testing.T) {
+		err := json.Unmarshal([]byte("42"), &atom)
+		require.Error(t, err, "json.Unmarshal didn't error as expected.")
+		assertErrorJSONUnmarshalType(t, err,
+			"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
+	})
 }

--- a/string_test.go
+++ b/string_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2016-2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,6 @@ package atomic
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,6 +52,6 @@ func TestString(t *testing.T) {
 
 	err = json.Unmarshal([]byte("42"), &atom)
 	require.Error(t, err, "json.Unmarshal didn't error as expected.")
-	require.True(t, errors.As(err, new(*json.UnmarshalTypeError)),
+	assertErrorJSONUnmarshalType(t, err,
 		"json.Unmarshal failed with unexpected error %v, want UnmarshalTypeError.", err)
 }


### PR DESCRIPTION
Change JSON marshaling and unmarshaling tests to use subtests for
cleaner separation in output as well as for easier visual scanning.