### PR TITLE
Disallow non-atomic comparisons of atomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- Disallow incorrect comparison of atomic values in a non-atomic way.
 
 ## [1.6.0] - 2020-02-24
 ### Changed

--- a/atomic.go
+++ b/atomic.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2016-2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,11 +30,15 @@ import (
 )
 
 // Bool is an atomic Boolean.
-type Bool struct{ v uint32 }
+type Bool struct {
+	nocmp // disallow non-atomic comparison
+
+	v uint32
+}
 
 // NewBool creates a Bool.
 func NewBool(initial bool) *Bool {
-	return &Bool{boolToInt(initial)}
+	return &Bool{v: boolToInt(initial)}
 }
 
 // Load atomically loads the Boolean.
@@ -95,12 +99,14 @@ func (b *Bool) UnmarshalJSON(t []byte) error {
 
 // Float64 is an atomic wrapper around float64.
 type Float64 struct {
+	nocmp // disallow non-atomic comparison
+
 	v uint64
 }
 
 // NewFloat64 creates a Float64.
 func NewFloat64(f float64) *Float64 {
-	return &Float64{math.Float64bits(f)}
+	return &Float64{v: math.Float64bits(f)}
 }
 
 // Load atomically loads the wrapped value.
@@ -152,6 +158,8 @@ func (f *Float64) UnmarshalJSON(b []byte) error {
 // Duration is an atomic wrapper around time.Duration
 // https://godoc.org/time#Duration
 type Duration struct {
+	nocmp // disallow non-atomic comparison
+
 	v Int64
 }
 
@@ -207,4 +215,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 // Value shadows the type of the same name from sync/atomic
 // https://godoc.org/sync/atomic#Value
-type Value struct{ atomic.Value }
+type Value struct {
+	nocmp // disallow non-atomic comparison
+	atomic.Value
+}

--- a/int32.go
+++ b/int32.go
@@ -28,11 +28,15 @@ import (
 )
 
 // Int32 is an atomic wrapper around int32.
-type Int32 struct{ v int32 }
+type Int32 struct {
+	nocmp // disallow non-atomic comparison
+
+	v int32
+}
 
 // NewInt32 creates a new Int32.
 func NewInt32(i int32) *Int32 {
-	return &Int32{i}
+	return &Int32{v: i}
 }
 
 // Load atomically loads the wrapped value.

--- a/int64.go
+++ b/int64.go
@@ -28,11 +28,15 @@ import (
 )
 
 // Int64 is an atomic wrapper around int64.
-type Int64 struct{ v int64 }
+type Int64 struct {
+	nocmp // disallow non-atomic comparison
+
+	v int64
+}
 
 // NewInt64 creates a new Int64.
 func NewInt64(i int64) *Int64 {
-	return &Int64{i}
+	return &Int64{v: i}
 }
 
 // Load atomically loads the wrapped value.

--- a/internal/gen-atomicint/main.go
+++ b/internal/gen-atomicint/main.go
@@ -133,11 +133,15 @@ import (
 )
 
 // {{ .Name }} is an atomic wrapper around {{ .Wrapped }}.
-type {{ .Name }} struct{ v {{ .Wrapped }} }
+type {{ .Name }} struct {
+	nocmp // disallow non-atomic comparison
+
+	v {{ .Wrapped }}
+}
 
 // New{{ .Name }} creates a new {{ .Name }}.
 func New{{ .Name }}(i {{ .Wrapped }}) *{{ .Name }} {
-	return &{{ .Name }}{i}
+	return &{{ .Name }}{v: i}
 }
 
 // Load atomically loads the wrapped value.

--- a/nocmp.go
+++ b/nocmp.go
@@ -32,6 +32,4 @@ package atomic
 //
 //  - Disallow shallow copies of structs
 //  - Disallow comparison of pointers to uncomparable structs
-type nocmp struct {
-	_ [0]func()
-}
+type nocmp [0]func()

--- a/nocmp.go
+++ b/nocmp.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package atomic
+
+// nocmp is an uncomparable struct. Embed this inside another struct to make
+// it uncomparable.
+//
+//  type Foo struct {
+//    nocmp
+//    // ...
+//  }
+//
+// This DOES NOT:
+//
+//  - Disallow shallow copies of structs
+//  - Disallow comparison of pointers to uncomparable structs
+type nocmp struct {
+	_ [0]func()
+}

--- a/nocmp_test.go
+++ b/nocmp_test.go
@@ -52,6 +52,18 @@ func TestNocmpComparability(t *testing.T) {
 			give:       &struct{ nocmp }{},
 			comparable: true,
 		},
+
+		// All exported types must be uncomparable.
+		{desc: "Bool", give: Bool{}},
+		{desc: "Duration", give: Duration{}},
+		{desc: "Error", give: Error{}},
+		{desc: "Float64", give: Float64{}},
+		{desc: "Int32", give: Int32{}},
+		{desc: "Int64", give: Int64{}},
+		{desc: "String", give: String{}},
+		{desc: "Uint32", give: Uint32{}},
+		{desc: "Uint64", give: Uint64{}},
+		{desc: "Value", give: Value{}},
 	}
 
 	for _, tt := range tests {

--- a/nocmp_test.go
+++ b/nocmp_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package atomic
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNocmpComparability(t *testing.T) {
+	tests := []struct {
+		desc       string
+		give       interface{}
+		comparable bool
+	}{
+		{
+			desc: "nocmp struct",
+			give: nocmp{},
+		},
+		{
+			desc: "struct with nocmp embedded",
+			give: struct{ nocmp }{},
+		},
+		{
+			desc:       "pointer to struct with nocmp embedded",
+			give:       &struct{ nocmp }{},
+			comparable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			typ := reflect.TypeOf(tt.give)
+			assert.Equalf(t, tt.comparable, typ.Comparable(),
+				"type %v comparablity mismatch", typ)
+		})
+	}
+}
+
+// nocmp must not add to the size of a struct in-memory.
+func TestNocmpSize(t *testing.T) {
+	type x struct{ i int }
+
+	before := reflect.TypeOf(x{}).Size()
+
+	type y struct {
+		nocmp
+
+		x x
+	}
+
+	after := reflect.TypeOf(x{}).Size()
+
+	assert.Equal(t, before, after,
+		"expected nocmp to have no effect on struct size")
+}
+
+// This test will fail to compile if we disallow copying of nocmp.
+//
+// We need to allow this so that users can do,
+//
+//   var x atomic.Int32
+//   x = atomic.NewInt32(1)
+func TestNocmpCopy(t *testing.T) {
+	type foo struct{ nocmp }
+
+	t.Run("struct copy", func(t *testing.T) {
+		a := foo{}
+		b := a
+		_ = b // unused
+	})
+
+	t.Run("pointer copy", func(t *testing.T) {
+		a := &foo{}
+		b := *a
+		_ = b // unused
+	})
+}
+
+const _badFile = `package atomic
+
+import "fmt"
+
+type Int64 struct {
+	nocmp
+
+	v int64
+}
+
+func shouldNotCompile() {
+	var x, y Int64
+	fmt.Println(x == y)
+}
+`
+
+func TestNocmpIntegration(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "nocmp")
+	require.NoError(t, err, "unable to set up temporary directory")
+	defer os.RemoveAll(tempdir)
+
+	src := filepath.Join(tempdir, "src")
+	require.NoError(t, os.Mkdir(src, 0755), "unable to make source directory")
+
+	nocmp, err := ioutil.ReadFile("nocmp.go")
+	require.NoError(t, err, "unable to read nocmp.go")
+
+	require.NoError(t,
+		ioutil.WriteFile(filepath.Join(src, "nocmp.go"), nocmp, 0644),
+		"unable to write nocmp.go")
+
+	require.NoError(t,
+		ioutil.WriteFile(filepath.Join(src, "bad.go"), []byte(_badFile), 0644),
+		"unable to write bad.go")
+
+	var stderr bytes.Buffer
+	cmd := exec.Command("go", "build")
+	cmd.Dir = src
+	// Forget OS build enviroment and set up a minimal one for "go build"
+	// to run.
+	cmd.Env = []string{
+		"GOCACHE=" + filepath.Join(tempdir, "gocache"),
+	}
+	cmd.Stderr = &stderr
+	require.Error(t, cmd.Run(), "bad.go must not compile")
+
+	assert.Contains(t, stderr.String(),
+		"struct containing nocmp cannot be compared")
+}

--- a/uint32.go
+++ b/uint32.go
@@ -28,11 +28,15 @@ import (
 )
 
 // Uint32 is an atomic wrapper around uint32.
-type Uint32 struct{ v uint32 }
+type Uint32 struct {
+	nocmp // disallow non-atomic comparison
+
+	v uint32
+}
 
 // NewUint32 creates a new Uint32.
 func NewUint32(i uint32) *Uint32 {
-	return &Uint32{i}
+	return &Uint32{v: i}
 }
 
 // Load atomically loads the wrapped value.

--- a/uint64.go
+++ b/uint64.go
@@ -28,11 +28,15 @@ import (
 )
 
 // Uint64 is an atomic wrapper around uint64.
-type Uint64 struct{ v uint64 }
+type Uint64 struct {
+	nocmp // disallow non-atomic comparison
+
+	v uint64
+}
 
 // NewUint64 creates a new Uint64.
 func NewUint64(i uint64) *Uint64 {
-	return &Uint64{i}
+	return &Uint64{v: i}
 }
 
 // Load atomically loads the wrapped value.


### PR DESCRIPTION
It is currently possible to make non-atomic comparisons of atomic
values:

    x := atomic.NewInt32(1)
    y := atomic.NewInt32(1)
    fmt.Println(*x == *y)

This is undesirable because it loads the value in a non-atomic way. The
correct method is,

    x := atomic.NewInt32(1)
    y := atomic.NewInt32(1)
    fmt.Println(x.Load() == y.Load())

To prevent this, disallow comparison of atomic values by embedding an
uncomparable array into atomics. The empty array adds no runtime cost,
and does not increase the in-memory size of the structs. Inspired by
[go4.org/mem#RO][1].

  [1]: https://github.com/go4org/mem/blob/3dbcd07079b881f9bedb802b4099856c1e267fa1/mem.go#L42

Note that the Value struct, which embeds `"sync/atomic".Value` was also
changed. This will break usages in the following form, but that's
acceptable because unkeyed struct literals are among the exceptions
stated in the [Go 1 compatibility expectations][2].

    import (
      syncatomic "sync/atomic"
      "go.uber.org/atomic"
    )

    atomic.Value{syncatomic.Value{..}}

  [2]: https://golang.org/doc/go1compat#expectations

Resolves #72