### PR TITLE
Prepare release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/uber-go/atomic/compare/v1.6.0...v1.7.0
+[1.7.0]: https://github.com/uber-go/atomic/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/uber-go/atomic/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/uber-go/atomic/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/uber-go/atomic/compare/v1.4.0...v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.0] - 2020-09-11
+### Added
+- Support JSON serialization and deserialization of primitive atomic types.
+- Support Text marshalling and unmarshalling for string atomics.
+
 ### Changed
 - Disallow incorrect comparison of atomic values in a non-atomic way.
 
@@ -59,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/uber-go/atomic/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/uber-go/atomic/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/uber-go/atomic/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/uber-go/atomic/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/uber-go/atomic/compare/v1.4.0...v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.0] - 2020-09-11
+## [1.7.0] - 2020-09-14
 ### Added
 - Support JSON serialization and deserialization of primitive atomic types.
 - Support Text marshalling and unmarshalling for string atomics.


### PR DESCRIPTION
Release v1.7.0 of atomic. This includes a couple additional features as
well as the correctness change introduced in (#74).