### PR TITLE
nomcmp/test: Only set HOME

### DIFF
--- a/nocmp_test.go
+++ b/nocmp_test.go
@@ -156,13 +156,9 @@ func TestNocmpIntegration(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd := exec.Command("go", "build")
 	cmd.Dir = tempdir
-	// Forget OS build enviroment and set up a minimal one for "go build"
-	// to run. We need GOPATH and GOCACHE set for the compiler to run but
-	// we don't do anything with them.
-	cmd.Env = []string{
-		"GOPATH=" + filepath.Join(tempdir, "gopath"),
-		"GOCACHE=" + filepath.Join(tempdir, "gocache"),
-	}
+	// Create a minimal build enviroment with only HOME set so that "go
+	// build" has somewhere to put the cache and other Go files in.
+	cmd.Env = []string{"HOME=" + filepath.Join(tempdir, "home")}
 	cmd.Stderr = &stderr
 	require.Error(t, cmd.Run(), "bad.go must not compile")
 


### PR DESCRIPTION
After some more digging into #83, the issue was actually lack of HOME.
We need to specify GOPATH and GOCACHE because we haven't specified a
HOME.

Given the setup,

```
cd $(mktemp -d)
echo "module example.com/demo" > go.mod
echo "package demo" > demo.go
eval $(gimme 1.16rc1)
GO=$(which go)
```

If we run `go build` with an empty environment, it fails as expected.

```
$ env -i $GO build
missing $GOPATH
```

Setting HOME gives it a good default place for GOPATH, GOCACHE, and
friends.

```
$ env -i HOME=$(pwd)/home $GO build  # succeeds
```
