### PR TITLE
fossa: Run separately, only on push

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,17 @@
+name: FOSSA Analysis
+on: push
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'uber-go'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: FOSSA analysis
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,11 +27,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: FOSSA analysis
-      uses: fossas/fossa-action@v1
-      with:
-        api-key: ${{ secrets.FOSSA_API_KEY }}
-
     - name: Load cached dependencies
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
FOSSA analysis currently blocks CI on pull requests because they are
denied access to secrets.

Run FOSSA as a separate job only when we push to a branch of the
project.

Before opening your pull request, please make sure that you've:

- [ ] updated the changelog if the change is user-facing;
- [ ] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [ ] added tests to cover your changes;
- [ ] run the test suite locally (`make test`); and finally,
- [ ] run the linters locally (`make lint`).

Thanks for your contribution!
