### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.8.0] - 2021-06-09
 ### Added
 - Add `atomic.Uintptr` type for atomic operations on `uintptr` values.
 - Add `atomic.UnsafePointer` type for atomic operations on `unsafe.Pointer` values.
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
+[1.8.0]: https://github.com/uber-go/atomic/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/uber-go/atomic/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/uber-go/atomic/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/uber-go/atomic/compare/v1.5.0...v1.5.1


### PR DESCRIPTION
Release v1.8.0 of atomic with support for atomic wrappers for uintptr
and unsafe.Pointer.
