### PR TITLE
Add note on Float64.CAS matching of NaN

### DIFF
--- a/float64.go
+++ b/float64.go
@@ -55,11 +55,6 @@ func (x *Float64) Store(v float64) {
 	x.v.Store(math.Float64bits(v))
 }
 
-// CAS is an atomic compare-and-swap for float64 values.
-func (x *Float64) CAS(o, n float64) bool {
-	return x.v.CAS(math.Float64bits(o), math.Float64bits(n))
-}
-
 // MarshalJSON encodes the wrapped float64 into JSON.
 func (x *Float64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(x.Load())


### PR DESCRIPTION
NaN != NaN when using Go's inbuilt operator, but the same is not true
when used with Float64.CAS. Add a note calling this out.

Changing this would be a behaviour change (requires a major version
bump), and is likely unsafe as it could lead to typical CAS loops
blocking forever.

To add the note, we copy the generated CAS method and extend the
documentation as the generator does not support per-method
customizations on the doc comments.

Thanks to @masiulaniec for calling this out and referencing https://github.com/golang/go/issues/21996#issuecomment-331687536