### PR TITLE
uintptr test: Fix overflow on architectures with 32-bit pointers

### DIFF
--- a/uintptr_test.go
+++ b/uintptr_test.go
@@ -22,7 +22,7 @@ package atomic
 
 import (
 	"encoding/json"
-	"math"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,8 +69,11 @@ func TestUintptr(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
 		// Use an integer with the signed bit set. If we're converting
 		// incorrectly, we'll get a negative value here.
-		atom := NewUintptr(uintptr(math.MaxUint64))
-		assert.Equal(t, "18446744073709551615", atom.String(),
+		// Use an int variable, as constants cause compile-time overflows.
+		negative := -1
+		atom := NewUintptr(uintptr(negative))
+		want := fmt.Sprint(uintptr(negative))
+		assert.Equal(t, want, atom.String(),
 			"String() returned an unexpected value.")
 	})
 }


### PR DESCRIPTION
Fixes #99

The current uintptr test assumes that pointers are 64-bit, so the test
fails to compile on architectures with 32-bit pointers. Instead, cast
-1 to uintptr, which matches math.MaxUint64 on 64-bit architectures, and
math.MaxUint32 on 32-bit architectures.

Verified by using GOARCH=386