### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `atomic.Uintptr` type for atomic operations on `uintptr` values.
 - Add `atomic.UnsafePointer` type for atomic operations on `unsafe.Pointer` values.
 
+[1.8.0]: https://github.com/uber-go/atomic/compare/v1.7.0...v1.8.0
+
 ## [1.7.0] - 2020-09-14
 ### Added
 - Support JSON serialization and deserialization of primitive atomic types.
@@ -25,13 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove dependency on `golang.org/x/{lint, tools}`.
 
+[1.7.0]: https://github.com/uber-go/atomic/compare/v1.6.0...v1.7.0
+
 ## [1.6.0] - 2020-02-24
 ### Changed
 - Drop library dependency on `golang.org/x/{lint, tools}`.
 
+[1.6.0]: https://github.com/uber-go/atomic/compare/v1.5.1...v1.6.0
+
 ## [1.5.1] - 2019-11-19
 - Fix bug where `Bool.CAS` and `Bool.Toggle` do work correctly together
   causing `CAS` to fail even though the old value matches.
+
+[1.5.1]: https://github.com/uber-go/atomic/compare/v1.5.0...v1.5.1
 
 ## [1.5.0] - 2019-10-29
 ### Changed
@@ -39,17 +47,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   If you need to use the old import path, please add a `replace` directive to
   your `go.mod`.
 
+[1.5.0]: https://github.com/uber-go/atomic/compare/v1.4.0...v1.5.0
+
 ## [1.4.0] - 2019-05-01
 ### Added
  - Add `atomic.Error` type for atomic operations on `error` values.
+
+[1.4.0]: https://github.com/uber-go/atomic/compare/v1.3.2...v1.4.0
 
 ## [1.3.2] - 2018-05-02
 ### Added
 - Add `atomic.Duration` type for atomic operations on `time.Duration` values.
 
+[1.3.2]: https://github.com/uber-go/atomic/compare/v1.3.1...v1.3.2
+
 ## [1.3.1] - 2017-11-14
 ### Fixed
 - Revert optimization for `atomic.String.Store("")` which caused data races.
+
+[1.3.1]: https://github.com/uber-go/atomic/compare/v1.3.0...v1.3.1
 
 ## [1.3.0] - 2017-11-13
 ### Added
@@ -58,9 +74,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Optimize `atomic.String.Store("")` by avoiding an allocation.
 
+[1.3.0]: https://github.com/uber-go/atomic/compare/v1.2.0...v1.3.0
+
 ## [1.2.0] - 2017-04-12
 ### Added
 - Shadow `atomic.Value` from `sync/atomic`.
+
+[1.2.0]: https://github.com/uber-go/atomic/compare/v1.1.0...v1.2.0
 
 ## [1.1.0] - 2017-03-10
 ### Added
@@ -69,19 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Support new `go.uber.org/atomic` import path.
 
+[1.1.0]: https://github.com/uber-go/atomic/compare/v1.0.0...v1.1.0
+
 ## [1.0.0] - 2016-07-18
 
 - Initial release.
 
-[1.8.0]: https://github.com/uber-go/atomic/compare/v1.7.0...v1.8.0
-[1.7.0]: https://github.com/uber-go/atomic/compare/v1.6.0...v1.7.0
-[1.6.0]: https://github.com/uber-go/atomic/compare/v1.5.1...v1.6.0
-[1.5.1]: https://github.com/uber-go/atomic/compare/v1.5.0...v1.5.1
-[1.5.0]: https://github.com/uber-go/atomic/compare/v1.4.0...v1.5.0
-[1.4.0]: https://github.com/uber-go/atomic/compare/v1.3.2...v1.4.0
-[1.3.2]: https://github.com/uber-go/atomic/compare/v1.3.1...v1.3.2
-[1.3.1]: https://github.com/uber-go/atomic/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/uber-go/atomic/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/uber-go/atomic/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/uber-go/atomic/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/uber-go/atomic/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.9.0] - 2021-07-15
 ### Added
 - Add `Float64.Swap` to match int atomic operations.
 - Add `atomic.Time` type for atomic operations on `time.Time` values.
+
+[1.9.0]: https://github.com/uber-go/atomic/compare/v1.8.0...v1.9.0
 
 ## [1.8.0] - 2021-06-09
 ### Added


### PR DESCRIPTION
This release v1.9.0 of go.uber.org/atomic. The list of changes in this releases
is [v1.8.0...997edd6][1].

[1]: https://github.com/uber-go/atomic/compare/v1.8.0...997edd6

In updating the changelog, I moved the reference links around so that each
reference link was in its own section rather than piled at the bottom of the
file where it gets pretty ungainly.
