### PR TITLE
Implement String method for pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Add `String` method to `atomic.Pointer[T]` type allowing users to safely print
+underlying values of pointers.
+
 ## [1.10.0] - 2022-08-11
 ### Added
 - Add `atomic.Float32` type for atomic operations on `float32`.

--- a/pointer_go118.go
+++ b/pointer_go118.go
@@ -27,5 +27,5 @@ import "fmt"
 
 // String returns a human readable representation of a Pointer's underlying value.
 func (p *Pointer[T]) String() string {
-	return fmt.Sprint(p.p.Load())
+	return fmt.Sprint(p.Load())
 }

--- a/pointer_go118_pre119.go
+++ b/pointer_go118_pre119.go
@@ -18,14 +18,43 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build go1.18
-// +build go1.18
+//go:build go1.18 && !go1.19
+// +build go1.18,!go1.19
 
 package atomic
 
-import "fmt"
+import "unsafe"
 
-// String returns a human readable representation of a Pointer's underlying value.
-func (p *Pointer[T]) String() string {
-	return fmt.Sprint(p.p.Load())
+type Pointer[T any] struct {
+	_ nocmp // disallow non-atomic comparison
+	p UnsafePointer
+}
+
+// NewPointer creates a new Pointer.
+func NewPointer[T any](v *T) *Pointer[T] {
+	var p Pointer[T]
+	if v != nil {
+		p.p.Store(unsafe.Pointer(v))
+	}
+	return &p
+}
+
+// Load atomically loads the wrapped value.
+func (p *Pointer[T]) Load() *T {
+	return (*T)(p.p.Load())
+}
+
+// Store atomically stores the passed value.
+func (p *Pointer[T]) Store(val *T) {
+	p.p.Store(unsafe.Pointer(val))
+}
+
+// Swap atomically swaps the wrapped pointer and returns the old value.
+func (p *Pointer[T]) Swap(val *T) (old *T) {
+	return (*T)(p.p.Swap(unsafe.Pointer(val)))
+}
+
+// CompareAndSwap is an atomic compare-and-swap.
+func (p *Pointer[T]) CompareAndSwap(old, new *T) (swapped bool) {
+	return p.p.CompareAndSwap(unsafe.Pointer(old), unsafe.Pointer(new))
 }

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -24,6 +24,7 @@
 package atomic
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,6 +89,10 @@ func TestPointer(t *testing.T) {
 				atom := tt.newAtomic()
 				atom.Store(&i)
 				require.Equal(t, &i, atom.Load(), "Store didn't set the correct value.")
+			})
+			t.Run("String", func(t *testing.T) {
+				atom := tt.newAtomic()
+				require.Equal(t, fmt.Sprint(tt.initial), atom.String(), "String did not return the correct value.")
 			})
 		})
 	}


### PR DESCRIPTION
By implementing this method ourselves using atomic loading and fmt.Sprint, we can avoid possible unguarded accesses to the embedded pointer if someone attempts to fmt.Print the atomic.Pointer
.

Before opening your pull request, please make sure that you've:

- [X] updated the changelog if the change is user-facing;
- [X] added tests to cover your changes;
- [X] run the test suite locally (`make test`); and finally,
- [X] run the linters locally (`make lint`).

Thanks for your contribution!
