### PR TITLE
Minimize permissions to CI workflows

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,6 +1,9 @@
 name: FOSSA Analysis
 on: push
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ['*']
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Set only read permission on CI workflows since they don't need write access.

Fixes #132.
