### PR TITLE
replace deprecated function CAS in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ provide a safer, more convenient API.
 var atom atomic.Uint32
 atom.Store(42)
 atom.Sub(2)
-atom.CAS(40, 11)
+atom.CompareAndSwap(40, 11)
 ```
 
 See the [documentation][doc] for a complete API specification.

--- a/example_test.go
+++ b/example_test.go
@@ -33,7 +33,7 @@ func Example() {
 	// The wrapper ensures that all operations are atomic.
 	atom.Store(42)
 	fmt.Println(atom.Inc())
-	fmt.Println(atom.CAS(43, 0))
+	fmt.Println(atom.CompareAndSwap(43, 0))
 	fmt.Println(atom.Load())
 
 	// Output:


### PR DESCRIPTION
replace deprecated function CAS in examples, reinforcing the use of CompareAndSwap

-----

Before opening your pull request, please make sure that you've:

- [ ] updated the changelog if the change is user-facing;
- [ ] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

