### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Auto-update tools dependencies, but not library dependencies.
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This sets up dependabot to update github actions and dependencies in `/tools`, modeled after [Fx's dependabot configuration](https://github.com/uber-go/fx/commit/96a3b1bc415e7f3279e648b57318c3007c835e41).